### PR TITLE
Add static server and document testing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Matma Henio
+
+Prosty projekt przeglądarkowy pomagający w utrwalaniu tabliczki mnożenia. Repozytorium zawiera dwie miniaplikacje:
+
+- **Poziomy z zadaniami** (`index.html`, `app.js`) – trzy zestawy losowo wybieranych zadań z tabliczki mnożenia.
+- **Wyzwanie z tabliczką** (`tabliczka.html`, `table.js`) – tabela 10×10 z losowo ukrytymi wynikami do uzupełnienia.
+
+## Uruchomienie lokalne
+
+Do lokalnego testowania wystarczy Node.js w wersji 18 lub nowszej. Projekt nie ma zależności zewnętrznych, więc nie trzeba instalować paczek.
+
+```bash
+node server.js
+```
+
+Po uruchomieniu w przeglądarce otwórz adres [http://localhost:3000](http://localhost:3000), aby przejść do strony głównej. Strona `tabliczka.html` jest dostępna pod adresem [http://localhost:3000/tabliczka.html](http://localhost:3000/tabliczka.html).
+
+### Zmiana portu
+
+Jeśli port `3000` jest zajęty, ustaw zmienną środowiskową `PORT`, np.:
+
+```bash
+PORT=4000 node server.js
+```
+
+## Szukanie błędów
+
+1. Otwórz narzędzia deweloperskie w przeglądarce (zazwyczaj klawisz <kbd>F12</kbd> lub <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd>).
+2. Na zakładce **Console** sprawdzaj, czy pojawiają się komunikaty o błędach JavaScript.
+3. W zakładce **Network** upewnij się, że wszystkie pliki statyczne (HTML, CSS, JS, czcionki) wczytują się poprawnie – status `200`.
+4. Przetestuj wprowadzanie poprawnych i niepoprawnych odpowiedzi w zadaniach oraz w tabeli.
+5. Zweryfikuj komunikaty o ukończeniu poziomu oraz o wypełnieniu całej tablicy.
+
+W razie wykrycia problemu możesz go zreprodukować, zapisując kroki i wartości wprowadzane podczas testów, a następnie zgłosić w Pull Requeście.

--- a/server.js
+++ b/server.js
@@ -1,1 +1,78 @@
+const http = require("http");
+const path = require("path");
+const fs = require("fs");
 
+const PORT = Number.parseInt(process.env.PORT ?? "3000", 10);
+const ROOT_DIR = __dirname;
+
+const MIME_TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".ico": "image/x-icon",
+  ".webp": "image/webp",
+};
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const safePath = sanitizePath(req.url ?? "/");
+    const filePath = path.join(ROOT_DIR, safePath);
+
+    if (!filePath.startsWith(ROOT_DIR)) {
+      res.writeHead(403, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("403 - Forbidden");
+      return;
+    }
+
+    const stats = await fs.promises.stat(filePath).catch(() => null);
+
+    if (!stats) {
+      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("404 - Not Found");
+      return;
+    }
+
+    const resolvedPath = stats.isDirectory()
+      ? path.join(filePath, "index.html")
+      : filePath;
+
+    const resolvedStats = await fs.promises.stat(resolvedPath).catch(() => null);
+
+    if (!resolvedStats || !resolvedStats.isFile()) {
+      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("404 - Not Found");
+      return;
+    }
+
+    const content = await fs.promises.readFile(resolvedPath);
+    const ext = path.extname(resolvedPath).toLowerCase();
+    const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
+
+    res.writeHead(200, { "Content-Type": contentType });
+    res.end(content);
+  } catch (error) {
+    console.error("Failed to serve request", error);
+    res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("500 - Internal Server Error");
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Static server running at http://localhost:${PORT}`);
+});
+
+function sanitizePath(rawUrl) {
+  const urlPath = rawUrl.split("?")[0].split("#")[0];
+  if (!urlPath || urlPath === "/") {
+    return "index.html";
+  }
+
+  const normalized = path.normalize(urlPath);
+  return normalized.replace(/^[/\\]+/, "");
+}


### PR DESCRIPTION
## Summary
- implement a lightweight Node.js static server for local testing
- guard against missing files and disallow path traversal when serving assets
- document local setup and manual testing steps in a new README

## Testing
- node server.js

------
https://chatgpt.com/codex/tasks/task_e_68dafad6e78c8331aa18f049b5a4af6b