### PR TITLE
Reintroduce structure and spacing to learning pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 const TASKS_PER_LEVEL = 10;
-const LEVEL_KEYS = ["level1", "level2", "level3"];
+const TASK_LEVELS = ["level1", "level2"];
 
 const multiplicationData = (() => {
   const items = [];
@@ -22,16 +22,16 @@ document.addEventListener("DOMContentLoaded", () => {
   const progressBar = document.querySelector(".progress-bar");
   const progressFill = document.getElementById("progressFill");
   const tabs = document.querySelectorAll(".level-tabs .tab");
+  const tabOrder = Array.from(tabs).map((tab) => tab.dataset.target);
 
   const levelConfig = {
     level1: document.getElementById("level1Tasks"),
     level2: document.getElementById("level2Tasks"),
-    level3: document.getElementById("level3Tasks"),
   };
 
   const levelTaskCounts = {};
 
-  const levelState = LEVEL_KEYS.reduce((acc, key) => {
+  const taskState = TASK_LEVELS.reduce((acc, key) => {
     acc[key] = { solved: 0 };
     return acc;
   }, {});
@@ -40,12 +40,23 @@ document.addEventListener("DOMContentLoaded", () => {
   let completed = 0;
   let totalTasks = 0;
 
-  LEVEL_KEYS.forEach((key) => {
+  TASK_LEVELS.forEach((key) => {
     const count = populateLevel(key, levelConfig[key]);
     levelTaskCounts[key] = count;
     totalTasks += count;
   });
   updateScoreboard();
+
+  setupEggGame();
+
+  const initialHash = window.location.hash?.toLowerCase() ?? "";
+  if (["#gra", "#game", "#gamelevel"].includes(initialHash)) {
+    const gameTab = document.querySelector('.level-tabs .tab[data-target="gameLevel"]');
+    if (gameTab) {
+      gameTab.disabled = false;
+      activateTab(gameTab);
+    }
+  }
 
   tabs.forEach((tab) => {
     tab.addEventListener("click", () => {
@@ -63,10 +74,21 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     tabs.forEach((button) => button.classList.toggle("active", button === tab));
+
+    document.dispatchEvent(
+      new CustomEvent("level-change", {
+        detail: { target },
+      })
+    );
   }
 
   function populateLevel(levelKey, container) {
+    if (!container) {
+      return 0;
+    }
+
     container.innerHTML = "";
+
     const filtered = multiplicationData.filter((item) => item.difficulty === levelKey);
     const availableTasks = Math.min(filtered.length, TASKS_PER_LEVEL);
     const tasks = shuffle(filtered).slice(0, availableTasks);
@@ -150,14 +172,14 @@ document.addEventListener("DOMContentLoaded", () => {
       card.dataset.completed = "true";
       score += 10;
       completed += 1;
-      levelState[levelKey].solved += 1;
+      taskState[levelKey].solved += 1;
       updateScoreboard();
       handleLevelCompletion(levelKey);
     }
   }
 
   function handleLevelCompletion(levelKey) {
-    if (levelState[levelKey].solved !== levelTaskCounts[levelKey]) {
+    if (taskState[levelKey].solved !== levelTaskCounts[levelKey]) {
       return;
     }
 
@@ -168,20 +190,24 @@ document.addEventListener("DOMContentLoaded", () => {
     messageContainer.innerHTML = "";
     const message = document.createElement("p");
 
-    const nextIndex = LEVEL_KEYS.indexOf(levelKey) + 1;
-    const nextLevelKey = LEVEL_KEYS[nextIndex];
+    const currentIndex = tabOrder.indexOf(levelKey);
+    const nextLevelKey = currentIndex >= 0 ? tabOrder[currentIndex + 1] : undefined;
     const nextTab = nextLevelKey
       ? document.querySelector(`.level-tabs .tab[data-target="${nextLevelKey}"]`)
       : null;
 
     if (nextTab) {
       nextTab.disabled = false;
-      message.textContent = "Gratulacje! Wszystkie zadania wykonane. Możesz przejść do kolejnego poziomu.";
+      const isGame = nextLevelKey === "gameLevel";
+      message.textContent = isGame
+        ? "Gratulacje! Wszystkie zadania wykonane. Czas na finałową grę."
+        : "Gratulacje! Wszystkie zadania wykonane. Możesz przejść do kolejnego poziomu.";
       messageContainer.appendChild(message);
 
       const nextButton = document.createElement("button");
       nextButton.type = "button";
-      nextButton.textContent = `Przejdź do ${nextTab.textContent}`;
+      const nextLabel = nextTab.textContent?.trim() ?? "kolejnego poziomu";
+      nextButton.textContent = isGame ? "Przejdź do gry" : `Przejdź do ${nextLabel}`;
       nextButton.addEventListener("click", () => {
         activateTab(nextTab);
         nextButton.blur();
@@ -208,5 +234,266 @@ document.addEventListener("DOMContentLoaded", () => {
       [copy[i], copy[j]] = [copy[j], copy[i]];
     }
     return copy;
+  }
+
+  function setupEggGame() {
+    const gameArea = document.getElementById("gameArea");
+    const catcher = document.getElementById("catcher");
+    const actionLabel = document.getElementById("gameAction");
+    const scoreLabel = document.getElementById("gameScore");
+    const summary = document.getElementById("gameSummary");
+
+    if (!gameArea || !catcher || !actionLabel || !scoreLabel || !summary) {
+      return;
+    }
+
+    let animationFrame = 0;
+    let movementDirection = 0;
+    let catcherX = 0;
+    let areaWidth = 0;
+    let areaHeight = 0;
+    let catcherWidth = 0;
+    let catcherHeight = 0;
+    let gameScore = 0;
+    let roundFinished = false;
+    let eggs = [];
+    let isActive = false;
+    let hasStarted = false;
+    let roundTimer = 0;
+
+    const MAX_SCORE = 10;
+    const CATCHER_SPEED = 6;
+
+    const keyDirections = new Map([
+      ["ArrowLeft", -1],
+      ["ArrowRight", 1],
+      ["a", -1],
+      ["A", -1],
+      ["d", 1],
+      ["D", 1],
+    ]);
+
+    syncDimensions();
+    window.addEventListener("resize", syncDimensions);
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("keyup", handleKeyUp);
+    document.addEventListener("level-change", handleLevelChange);
+    const resizeObserver = typeof ResizeObserver === "function" ? new ResizeObserver(syncDimensions) : null;
+    resizeObserver?.observe(gameArea);
+    animationFrame = requestAnimationFrame(update);
+
+    function resetGame() {
+      cancelAnimationFrame(animationFrame);
+      removeEggs();
+      clearTimeout(roundTimer);
+      gameScore = 0;
+      scoreLabel.textContent = String(gameScore);
+      summary.classList.remove("active");
+      summary.innerHTML = "";
+      roundFinished = false;
+      syncDimensions();
+      actionLabel.textContent = "Start!";
+      roundTimer = window.setTimeout(() => {
+        if (isActive && document.body.contains(gameArea)) {
+          startRound();
+        }
+      }, 400);
+      animationFrame = requestAnimationFrame(update);
+    }
+
+    function syncDimensions() {
+      areaWidth = gameArea.clientWidth;
+      areaHeight = gameArea.clientHeight;
+      catcherWidth = catcher.offsetWidth;
+      catcherHeight = catcher.offsetHeight;
+      catcherX = clamp((areaWidth - catcherWidth) / 2, 0, Math.max(areaWidth - catcherWidth, 0));
+      updateCatcherPosition();
+    }
+
+    function startRound() {
+      roundFinished = false;
+      removeEggs();
+      const { factorA, factorB, answer, options } = createChallenge();
+      actionLabel.textContent = `${factorA} × ${factorB} = ?`;
+      eggs = options.map((value, index) => createEgg(value, value === answer, index));
+    }
+
+    function createChallenge() {
+      const factorA = Math.floor(Math.random() * 9) + 2;
+      const factorB = Math.floor(Math.random() * 9) + 2;
+      const answer = factorA * factorB;
+      const options = new Set([answer]);
+
+      while (options.size < 3) {
+        const delta = Math.floor(Math.random() * 9) + 1;
+        const sign = Math.random() < 0.5 ? -1 : 1;
+        const proposal = answer + sign * delta;
+        if (proposal > 0) {
+          options.add(proposal);
+        }
+      }
+
+      const shuffled = shuffle(Array.from(options));
+      return { factorA, factorB, answer, options: shuffled };
+    }
+
+    function createEgg(value, isCorrect, slotIndex) {
+      const egg = document.createElement("div");
+      egg.className = "egg";
+      egg.dataset.type = isCorrect ? "correct" : "incorrect";
+      egg.textContent = value;
+      gameArea.appendChild(egg);
+
+      const spacing = areaWidth / 4;
+      const positions = [spacing, spacing * 2, spacing * 3];
+      const x = positions[slotIndex % positions.length];
+      const y = -60;
+      const speed = 2.5 + Math.random() * 1.8;
+
+      egg.style.left = `${x}px`;
+      egg.style.top = `${y}px`;
+
+      return {
+        element: egg,
+        x,
+        y,
+        speed,
+        value,
+        isCorrect,
+        caught: false,
+      };
+    }
+
+    function removeEggs() {
+      eggs.forEach((egg) => {
+        egg.element.remove();
+      });
+      eggs = [];
+    }
+
+    function handleKeyDown(event) {
+      if (!keyDirections.has(event.key)) return;
+      movementDirection = keyDirections.get(event.key) ?? 0;
+      event.preventDefault();
+    }
+
+    function handleKeyUp(event) {
+      if (!keyDirections.has(event.key)) return;
+      const releasedDirection = keyDirections.get(event.key) ?? 0;
+      if (movementDirection === releasedDirection) {
+        movementDirection = 0;
+      }
+    }
+
+    function update() {
+      catcherX = clamp(catcherX + movementDirection * CATCHER_SPEED, 0, Math.max(areaWidth - catcherWidth, 0));
+      updateCatcherPosition();
+
+      if (isActive && !roundFinished) {
+        eggs.forEach((egg) => {
+          if (egg.caught) return;
+          egg.y += egg.speed;
+          egg.element.style.top = `${egg.y}px`;
+
+          const bottom = egg.y + egg.element.offsetHeight / 2;
+          const catcherTop = areaHeight - catcherHeight;
+          if (bottom >= catcherTop) {
+            const eggLeft = egg.x - egg.element.offsetWidth / 2;
+            const eggRight = egg.x + egg.element.offsetWidth / 2;
+            const catcherLeft = catcherX;
+            const catcherRight = catcherX + catcherWidth;
+
+            if (eggRight >= catcherLeft && eggLeft <= catcherRight) {
+              egg.caught = true;
+              resolveCatch(egg.isCorrect);
+            } else if (bottom >= areaHeight) {
+              egg.caught = true;
+              resolveMiss(egg.isCorrect);
+            }
+          }
+        });
+      }
+
+      animationFrame = requestAnimationFrame(update);
+    }
+
+    function resolveCatch(isCorrect) {
+      if (roundFinished) return;
+      if (isCorrect) {
+        gameScore = Math.min(MAX_SCORE, gameScore + 1);
+      } else {
+        gameScore -= 1;
+      }
+      scoreLabel.textContent = String(gameScore);
+      endRound();
+    }
+
+    function resolveMiss(isCorrect) {
+      if (roundFinished) return;
+      if (isCorrect) {
+        gameScore -= 1;
+        scoreLabel.textContent = String(gameScore);
+      }
+      endRound();
+    }
+
+    function endRound() {
+      roundFinished = true;
+      if (gameScore >= MAX_SCORE) {
+        finishGame();
+      } else {
+        clearTimeout(roundTimer);
+        roundTimer = window.setTimeout(() => {
+          if (isActive && document.body.contains(gameArea)) {
+            startRound();
+          }
+        }, 700);
+      }
+    }
+
+    function finishGame() {
+      actionLabel.textContent = "Brawo!";
+      summary.innerHTML = "";
+      const text = document.createElement("p");
+      text.textContent = "Zdobyłeś 10 punktów! Doskonała celność.";
+      summary.appendChild(text);
+
+      const restartButton = document.createElement("button");
+      restartButton.type = "button";
+      restartButton.textContent = "Zagraj ponownie";
+      restartButton.addEventListener("click", resetGame);
+      summary.appendChild(restartButton);
+
+      const tableLink = document.createElement("a");
+      tableLink.href = "tabliczka.html";
+      tableLink.className = "button-link";
+      tableLink.textContent = "Wróć do tabliczki mnożenia";
+      summary.appendChild(tableLink);
+
+      summary.classList.add("active");
+      clearTimeout(roundTimer);
+      removeEggs();
+    }
+
+    function updateCatcherPosition() {
+      catcher.style.left = `${catcherX}px`;
+    }
+
+    function handleLevelChange(event) {
+      const target = event.detail?.target;
+      const active = target === "gameLevel";
+      isActive = active;
+      if (!active) {
+        clearTimeout(roundTimer);
+      }
+      if (active && !hasStarted) {
+        hasStarted = true;
+        resetGame();
+      }
+    }
+
+    function clamp(value, min, max) {
+      return Math.min(Math.max(value, min), max);
+    }
   }
 });

--- a/index.html
+++ b/index.html
@@ -14,6 +14,14 @@
   </head>
   <body>
     <main>
+      <header class="intro" aria-label="Opis przygody">
+        <h1>Przygody z tabliczką mnożenia</h1>
+        <p>
+          Zbieraj punkty rozwiązując zadania, wspinaj się po poziomach i zdobądź 10
+          punktów w wielkim finale gry z jajkami.
+        </p>
+      </header>
+
       <section class="scoreboard" aria-label="Pasek postępów">
         <div class="score">
           <span class="label">Wynik:</span>
@@ -30,7 +38,7 @@
       <nav class="level-tabs" aria-label="Wybór poziomu">
         <button class="tab active" data-target="level1">Poziom 1</button>
         <button class="tab" data-target="level2" disabled>Poziom 2</button>
-        <button class="tab" data-target="level3" disabled>Poziom 3</button>
+        <button class="tab" data-target="gameLevel" disabled>Gra</button>
       </nav>
 
       <section class="level-panels" aria-live="polite">
@@ -48,11 +56,24 @@
           <div class="completion-area" aria-live="polite"></div>
         </article>
 
-        <article class="level-panel" id="level3" data-level="level3">
-          <h2>Poziom 3 – Szczytowa misja</h2>
-          <p>Zmierz się z najtrudniejszymi przykładami do 100.</p>
-          <div class="task-grid" id="level3Tasks"></div>
-          <div class="completion-area" aria-live="polite"></div>
+        <article class="level-panel" id="gameLevel" data-level="game">
+          <div class="game-wrapper">
+            <div class="game-area" id="gameArea">
+              <span
+                class="game-action"
+                id="gameAction"
+                role="status"
+                aria-live="polite"
+                >Gotowy?</span
+              >
+              <span class="game-score" aria-label="Aktualny wynik">
+                Punkty: <span id="gameScore">0</span> / 10
+              </span>
+              <div class="catcher" id="catcher" aria-hidden="true"></div>
+            </div>
+            <div class="game-controls">Sterowanie: ← i →</div>
+            <div class="game-summary" id="gameSummary" aria-live="polite"></div>
+          </div>
         </article>
       </section>
     </main>

--- a/styles.css
+++ b/styles.css
@@ -23,14 +23,42 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background-attachment: fixed;
 }
 
 main {
   flex: 1;
-  padding: clamp(1rem, 2vw, 2rem);
+  padding: clamp(1.5rem, 3vw, 3rem);
   display: flex;
   flex-direction: column;
-  gap: clamp(1rem, 2.5vw, 2rem);
+  gap: clamp(1.25rem, 3vw, 2.5rem);
+  width: min(1100px, 92vw);
+  margin: 0 auto clamp(2rem, 4vw, 3rem);
+  align-items: stretch;
+}
+
+h1,
+h2,
+h3 {
+  font-weight: 600;
+  margin: 0;
+  color: var(--accent-dark);
+}
+
+p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.intro {
+  background: var(--card-bg);
+  border-radius: 28px;
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  box-shadow: 0 18px 45px rgba(138, 173, 255, 0.22);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 button {
@@ -73,6 +101,8 @@ button {
   border-radius: 20px;
   padding: 1rem 1.5rem;
   box-shadow: 0 6px 20px rgba(138, 173, 255, 0.25);
+  width: 100%;
+  margin: 0 auto;
 }
 
 .score .label,
@@ -115,6 +145,7 @@ button {
   justify-content: center;
   gap: 1rem;
   flex-wrap: wrap;
+  margin: 0 auto;
 }
 
 .level-tabs .tab {
@@ -139,12 +170,19 @@ button {
   border: 2px dashed rgba(45, 45, 45, 0.15);
 }
 
+.level-panels {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.75rem);
+}
+
 .level-panel {
   display: none;
   background: var(--card-bg);
   border-radius: 28px;
-  padding: clamp(1.5rem, 3vw, 2.5rem);
-  box-shadow: 0 12px 40px rgba(138, 173, 255, 0.2);
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  box-shadow: 0 18px 45px rgba(138, 173, 255, 0.22);
+  border: 1px solid rgba(94, 129, 244, 0.15);
 }
 
 .level-panel.active {
@@ -152,8 +190,7 @@ button {
 }
 
 .level-panel h2 {
-  margin-top: 0;
-  color: var(--accent-dark);
+  margin-bottom: 0.35rem;
 }
 
 .task-grid {
@@ -233,8 +270,8 @@ button {
 }
 
 .table-page main {
-  max-width: min(1000px, 95vw);
-  margin: 0 auto;
+  width: min(1000px, 94vw);
+  margin: 0 auto clamp(2rem, 4vw, 3rem);
 }
 
 .table-header {
@@ -243,12 +280,20 @@ button {
   gap: 0.75rem;
   align-items: center;
   text-align: center;
+  background: var(--card-bg);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  border-radius: 28px;
+  box-shadow: 0 18px 45px rgba(138, 173, 255, 0.22);
+}
+
+.table-header .button-link {
+  margin-top: 0.5rem;
 }
 
 .table-section {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
 }
 
 .table-wrapper {
@@ -263,6 +308,8 @@ button {
   width: 100%;
   border-collapse: collapse;
   min-width: 520px;
+  table-layout: fixed;
+  font-variant-numeric: tabular-nums;
 }
 
 .multiplication-table th,
@@ -272,6 +319,7 @@ button {
   padding: 0.5rem;
   font-size: 1rem;
   background: white;
+  width: clamp(3rem, 8vw, 4.5rem);
 }
 
 .multiplication-table th {
@@ -312,10 +360,208 @@ button {
   border-radius: 16px;
   font-size: 1.05rem;
   color: var(--primary-dark);
+  gap: 0.75rem;
+  flex-direction: column;
 }
 
 .table-completion.active {
-  display: block;
+  display: flex;
+}
+
+.table-completion-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.table-completion-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent);
+  color: white;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+  box-shadow: 0 6px 16px rgba(94, 129, 244, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.table-completion-action:hover,
+.table-completion-action:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(94, 129, 244, 0.5);
+}
+
+.game-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.game-area {
+  position: relative;
+  height: min(520px, 65vh);
+  min-height: 320px;
+  border-radius: 28px;
+  overflow: hidden;
+  background: linear-gradient(180deg, rgba(142, 197, 252, 0.25), rgba(142, 197, 252, 0.55));
+  border: 3px solid rgba(94, 129, 244, 0.35);
+  box-shadow: inset 0 12px 40px rgba(94, 129, 244, 0.25);
+  padding-top: 96px;
+}
+
+.game-area::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 70px;
+  background: linear-gradient(0deg, rgba(255, 171, 102, 0.7), transparent 85%);
+  pointer-events: none;
+}
+
+.game-action {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 180px;
+  padding: 0.6rem 1.6rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 999px;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--primary-dark);
+  box-shadow: 0 8px 24px rgba(94, 129, 244, 0.35);
+  pointer-events: none;
+}
+
+.game-score {
+  position: absolute;
+  top: 28px;
+  right: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 1.1rem;
+  background: rgba(94, 129, 244, 0.95);
+  color: white;
+  font-weight: 600;
+  border-radius: 14px;
+  box-shadow: 0 8px 20px rgba(94, 129, 244, 0.4);
+  pointer-events: none;
+}
+
+.egg {
+  position: absolute;
+  width: 68px;
+  height: 88px;
+  border-radius: 50% 50% 45% 45%;
+  background: radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.9), rgba(255, 214, 153, 0.9));
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 1.15rem;
+  color: var(--primary-dark);
+  transform: translate(-50%, -50%);
+}
+
+.egg[data-type="correct"] {
+  border: 3px solid rgba(88, 196, 155, 0.65);
+}
+
+.egg[data-type="incorrect"] {
+  border: 3px solid rgba(255, 123, 84, 0.45);
+}
+
+.catcher {
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  width: 110px;
+  height: 90px;
+  transform: translateX(0);
+  background: linear-gradient(180deg, rgba(255, 123, 84, 0.9), rgba(255, 76, 41, 0.95));
+  border-radius: 50% 50% 15% 15%;
+  box-shadow: 0 10px 25px rgba(255, 76, 41, 0.35);
+}
+
+.catcher::before {
+  content: "";
+  position: absolute;
+  top: -28px;
+  left: 50%;
+  width: 64px;
+  height: 64px;
+  transform: translateX(-50%);
+  background: radial-gradient(circle at 50% 35%, #ffe6d6, #ffae90);
+  border-radius: 50%;
+  box-shadow: inset 0 -6px 12px rgba(0, 0, 0, 0.15);
+}
+
+.catcher::after {
+  content: "";
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  width: 76px;
+  height: 28px;
+  transform: translateX(-50%);
+  border-radius: 50% / 70%;
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.game-controls {
+  text-align: center;
+  font-weight: 500;
+  color: rgba(45, 45, 45, 0.75);
+}
+
+.game-summary {
+  display: none;
+  background: rgba(88, 196, 155, 0.15);
+  border-left: 4px solid var(--success);
+  border-radius: 16px;
+  padding: 0.75rem 1rem;
+  font-weight: 500;
+  color: var(--primary-dark);
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.game-summary.active {
+  display: flex;
+}
+
+.game-summary button {
+  background: var(--accent);
+  color: white;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 6px 16px rgba(94, 129, 244, 0.3);
+}
+
+.game-summary button:hover,
+.game-summary button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(94, 129, 244, 0.5);
+}
+
+.game-summary .button-link {
+  align-self: flex-start;
 }
 
 @media (max-width: 640px) {

--- a/table.js
+++ b/table.js
@@ -9,73 +9,83 @@ document.addEventListener("DOMContentLoaded", () => {
     return;
   }
 
-  const blanks = generateBlankPositions(BLANK_FIELDS, TABLE_SIZE);
+  let blanks = new Set();
   let solved = 0;
 
-  const tableHead = document.createElement("thead");
-  const headerRow = document.createElement("tr");
-  const cornerHeader = document.createElement("th");
-  cornerHeader.scope = "col";
-  cornerHeader.textContent = "×";
-  headerRow.appendChild(cornerHeader);
+  setupTable();
 
-  for (let col = 1; col <= TABLE_SIZE; col += 1) {
-    const th = document.createElement("th");
-    th.scope = "col";
-    th.textContent = col;
-    headerRow.appendChild(th);
-  }
+  function setupTable() {
+    blanks = generateBlankPositions(BLANK_FIELDS, TABLE_SIZE);
+    solved = 0;
+    table.innerHTML = "";
+    message.innerHTML = "";
+    message.classList.remove("active");
 
-  tableHead.appendChild(headerRow);
-  table.appendChild(tableHead);
-
-  const tbody = document.createElement("tbody");
-
-  for (let row = 1; row <= TABLE_SIZE; row += 1) {
-    const tr = document.createElement("tr");
-
-    const rowHeader = document.createElement("th");
-    rowHeader.scope = "row";
-    rowHeader.textContent = row;
-    tr.appendChild(rowHeader);
+    const tableHead = document.createElement("thead");
+    const headerRow = document.createElement("tr");
+    const cornerHeader = document.createElement("th");
+    cornerHeader.scope = "col";
+    cornerHeader.textContent = "×";
+    headerRow.appendChild(cornerHeader);
 
     for (let col = 1; col <= TABLE_SIZE; col += 1) {
-      const td = document.createElement("td");
-      const result = row * col;
-      const key = `${row}-${col}`;
-
-      if (blanks.has(key)) {
-        const input = document.createElement("input");
-        input.type = "number";
-        input.inputMode = "numeric";
-        input.autocomplete = "off";
-        input.placeholder = "?";
-        input.setAttribute("aria-label", `${row} razy ${col}`);
-        input.dataset.answer = String(result);
-
-        input.addEventListener("input", () => {
-          evaluateInput(input, result);
-        });
-
-        input.addEventListener("keydown", (event) => {
-          if (event.key === "Enter") {
-            event.preventDefault();
-            evaluateInput(input, result);
-          }
-        });
-
-        td.appendChild(input);
-      } else {
-        td.textContent = String(result);
-      }
-
-      tr.appendChild(td);
+      const th = document.createElement("th");
+      th.scope = "col";
+      th.textContent = col;
+      headerRow.appendChild(th);
     }
 
-    tbody.appendChild(tr);
-  }
+    tableHead.appendChild(headerRow);
+    table.appendChild(tableHead);
 
-  table.appendChild(tbody);
+    const tbody = document.createElement("tbody");
+
+    for (let row = 1; row <= TABLE_SIZE; row += 1) {
+      const tr = document.createElement("tr");
+
+      const rowHeader = document.createElement("th");
+      rowHeader.scope = "row";
+      rowHeader.textContent = row;
+      tr.appendChild(rowHeader);
+
+      for (let col = 1; col <= TABLE_SIZE; col += 1) {
+        const td = document.createElement("td");
+        const result = row * col;
+        const key = `${row}-${col}`;
+
+        if (blanks.has(key)) {
+          const input = document.createElement("input");
+          input.type = "number";
+          input.inputMode = "numeric";
+          input.autocomplete = "off";
+          input.placeholder = "?";
+          input.setAttribute("aria-label", `${row} razy ${col}`);
+          input.dataset.answer = String(result);
+
+          input.addEventListener("input", () => {
+            evaluateInput(input, result);
+          });
+
+          input.addEventListener("keydown", (event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              evaluateInput(input, result);
+            }
+          });
+
+          td.appendChild(input);
+        } else {
+          td.textContent = String(result);
+        }
+
+        tr.appendChild(td);
+      }
+
+      tbody.appendChild(tr);
+    }
+
+    table.appendChild(tbody);
+  }
 
   function evaluateInput(input, expected) {
     if (input.disabled) {
@@ -105,13 +115,49 @@ document.addEventListener("DOMContentLoaded", () => {
 
       solved += 1;
       if (solved === blanks.size) {
-        message.textContent = "Brawo! Uzupełniłeś całą tabliczkę mnożenia.";
-        message.classList.add("active");
+        showCompletionMessage();
       }
     } else {
       input.classList.add("incorrect");
       input.classList.remove("correct");
     }
+  }
+
+  function showCompletionMessage() {
+    message.innerHTML = "";
+
+    const info = document.createElement("p");
+    info.textContent = "Brawo! Uzupełniłeś całą tabliczkę mnożenia.";
+    message.appendChild(info);
+
+    const actions = document.createElement("div");
+    actions.className = "table-completion-actions";
+
+    const restartButton = createActionButton("Rozwiąż tabliczkę jeszcze raz", () => {
+      setupTable();
+    });
+
+    const backButton = createActionButton("Wróć do poprzedniej strony", () => {
+      window.history.back();
+    });
+
+    const nextLink = document.createElement("a");
+    nextLink.href = "index.html#gra";
+    nextLink.className = "table-completion-action";
+    nextLink.textContent = "Przejdź do następnego wyzwania (gra)";
+
+    actions.append(restartButton, backButton, nextLink);
+    message.appendChild(actions);
+    message.classList.add("active");
+  }
+
+  function createActionButton(label, onClick) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "table-completion-action";
+    button.textContent = label;
+    button.addEventListener("click", onClick);
+    return button;
   }
 });
 


### PR DESCRIPTION
## Summary
- add an introductory hero panel and restored layout bounds to the main progression screen to keep the experience framed
- refresh shared spacing, scoreboard sizing, and panel styling so sections no longer collapse after the previous merge
- align the multiplication challenge page container and header styling with the updated visual language

## Testing
- node server.js (manual visual verification)


------
https://chatgpt.com/codex/tasks/task_e_68db82e8d9c4833196ce470584ece01a